### PR TITLE
Adds log levels, env variable for level

### DIFF
--- a/assets/js/libs/mavMission.js
+++ b/assets/js/libs/mavMission.js
@@ -19,14 +19,9 @@ var uavConnection;
 // Handler when the ArduPilot requests individual waypoints: upon receiving a request,
 // Send the next one.
 function missionRequestHandler(missionItemRequest) {
-    log.info('Sending mission sequence number ' + missionItemRequest.seq);
+    log.debug('Sending mission sequence number ' + missionItemRequest.seq);
     mavlinkParser.send(missionItems[missionItemRequest.seq], uavConnection);
 }
-
-function missionAckHandler(ack) {
-    log.info('Received mission ack, mission items loaded onto payload.');
-}
-
 
 // Mapping from numbers (as those stored in waypoint files) to MAVLink commands.
 var commandMap;
@@ -48,7 +43,7 @@ util.inherits(MavMission, events.EventEmitter);
 
 // http://qgroundcontrol.org/mavlink/waypoint_protocol
 MavMission.prototype.sendToPlatform = function() {
-    log.info('Sending mission to platform...');
+    log.silly('Sending mission to platform...');
     // send mission_count
     var missionCount = new mavlink.messages.mission_count(mavlinkParser.srcSystem, mavlinkParser.srcComponent, missionItems.length);
     mavlinkParser.send(missionCount, uavConnection);

--- a/assets/js/libs/mavParam.js
+++ b/assets/js/libs/mavParam.js
@@ -45,11 +45,11 @@ MavParam.prototype.set = function(name, value) {
     // Guard if active promise for the given key.
     // Todo: enhance to also match key/value?
     if( _.has(promises, name )) {
-        log.info('Duplicate parameter set request sent for [' + name + '], currently active and unresolved.');
+        log.warn('Duplicate parameter set request sent for [' + name + '], currently active and unresolved.');
         return;
     }
 
-    log.info('Requesting parameter [' + name + '] be set to [' + value + ']...');
+    log.debug('Requesting parameter [' + name + '] be set to [' + value + ']...');
 
     // Build PARAM_SET message to send.
     var paramSetter = function() {
@@ -65,7 +65,7 @@ MavParam.prototype.set = function(name, value) {
             deferreds[name].resolve();
             delete deferreds[name];
             delete promises[name];
-            log.info('Verified parameter [' + name + '] set to [' + value + ']');
+            log.debug('Verified parameter [' + name + '] set to [' + value + ']');
         }
     }, this);
 

--- a/assets/js/libs/uavConnection.js
+++ b/assets/js/libs/uavConnection.js
@@ -63,7 +63,7 @@ util.inherits(UavConnection, events.EventEmitter);
 UavConnection.prototype.changeState = function(newState) {
     this.state = newState;
     this.emit(this.state);
-    log.info('[UavConnection] Changing state to [' + this.state + ']');
+    log.verbose('[UavConnection] Changing state to [' + this.state + ']');
     this.invokeState(this.state);
 };
 
@@ -77,7 +77,7 @@ UavConnection.prototype.heartbeat = function() {
     this.emit('heartbeat');
 
     this.invokeState(this.state);
-    log.info('time since last heartbeat: '+this.timeSinceLastHeartbeat);
+    log.silly('time since last heartbeat: '+this.timeSinceLastHeartbeat);
 };
 
 // Convenience function to make the meaning of the awkward syntax more clear.
@@ -88,7 +88,7 @@ UavConnection.prototype.invokeState = function(state) {
 UavConnection.prototype.start = function() {
     
     if(true === this.started) {
-        log.info('Asked to start connection manager, but connection already started, refused.');
+        log.warn('Asked to start connection manager, but connection already started, refused.');
         return;
     }
 
@@ -108,7 +108,7 @@ UavConnection.prototype.getState = function() {
 UavConnection.prototype.updateHeartbeat = function() {
     
     this.emit('heartbeat:packet');
-    log.info('Heartbeat updated: ' + Date.now());
+    log.silly('Heartbeat updated: ' + Date.now());
     this.lastHeartbeat = Date.now();
 
     // When we get a heartbeat, switch back to connected state.
@@ -162,22 +162,22 @@ UavConnection.prototype.disconnected = function() {
                     port: this.config.get('tcp:port')
                 }, _.bind(function() {
                     // 'connect' event listener
-                    log.info('[UavConnection] TCP connection established on port ' + this.config.get('tcp:port'));
+                    log.verbose('[UavConnection] TCP connection established on port ' + this.config.get('tcp:port'));
                     this.changeState('connecting');
                 }, this));
 
                 // We need to handle the 'error' event for TCP connections, otherwise its default behavior is to
                 // throw an exception, which may not be what is expected in the surrounding code.
                 this.connection.on('error', function(e) {
-                    log.info("[UavConnection] TCP connection error message: " + e);
+                    log.error("[UavConnection] TCP connection error message: " + e);
                 });
                 break;
 
             default:
-                log.info('Connection type not understood (' + this.config.get('connection') + ')');
+                log.error('Connection type not understood (%s)', this.config.get('connection'));
         }
     } catch (e) {
-        log.log('error', e);
+        log.error('error', e);
     }
 };
 
@@ -188,7 +188,7 @@ UavConnection.prototype.connecting = function() {
 
         this.isConnected = false;
 
-        log.info('establishing MAVLink connection...');
+        log.silly('establishing MAVLink connection...');
 
         // If necessary, attach the message parser to the connection.
         // This is only done the first time the connection reaches this state after first connecting,
@@ -207,7 +207,7 @@ UavConnection.prototype.connecting = function() {
         this.attachDataEventListener = false;
 
     } catch (e) {
-        log.info('Error!');
+        log.error('Error!', e);
         throw (e);
     }
 };

--- a/server.js
+++ b/server.js
@@ -24,14 +24,16 @@ requirejs.config({
     baseUrl: './app'
 });
 
-// Logger
-var logger = new(winston.Logger)({
-    transports: [
-        new(winston.transports.File)({
-            filename: 'mavlink.dev.log'
-        })
-    ]
+// Configure Winston
+var logger = module.exports = new (winston.Logger)({
+  transports: [
+    new (winston.transports.Console)({
+      colorize: true,
+      level: process.env.GCS_LOG_LEVEL // if undefined, will be 'info'.
+    })
+  ]
 });
+logger.setLevels(winston.config.npm.levels);
 
 // Fetch configuration information.
 nconf.argv().env().file({


### PR DESCRIPTION
Configures logger to use npm-style logging (silly, debug, verbose, info, warn, error).  Set the GCS_LOG_LEVEL env variable to adjust runtime level.  Logs are now only output as a console stream, not to a file.
