### PR TITLE
Fixes #152, typo caught by linter.

### DIFF
--- a/assets/js/libs/udlImplementations/ArduCopter.js
+++ b/assets/js/libs/udlImplementations/ArduCopter.js
@@ -286,7 +286,7 @@ ArduCopterUdl.prototype.rtl = function() {
     protocol.on('HEARTBEAT', function confirmRtlMode(msg) {
         
         try {
-            if (msg.custom_mode == apm.custom_modes.RTL) {
+            if (msg.custom_mode == APM.custom_modes.RTL) {
                 log.info('ArduCopter UDL: mode confirmed set to RTL mode!');
                 protocol.removeListener('HEARTBEAT', confirmRtlMode);
                 deferred.resolve();


### PR DESCRIPTION
Impact of this typo was that the promise for RTL mode was never resolved, and the heartbeat listener was never detached from the protocol.  No functional impact, but a good catch.
