### PR TITLE
Fixes #167, adds SITL as platform

### DIFF
--- a/app/Views/Plan.js
+++ b/app/Views/Plan.js
@@ -17,7 +17,7 @@ define(['backbone', 'JST'], function(Backbone, templates) {
             
             // Render scaffolding, filling in the gaps as provided
             this.$el.html(this.template({
-                platforms: app.platforms,
+                platforms: appConfig.platforms,
                 currentPlatform: this.model.get('platformId'),
                 currentPayload: this.model.get('payload'),
                 currentMission: this.model.get('mission')

--- a/app/routines/components/Routine.js
+++ b/app/routines/components/Routine.js
@@ -59,12 +59,19 @@ define([
 
         // A few promises for keeping track of various async processes.
         var connectionEstablishedDeferred = Q.defer(); // After connection is confirmed with UAV
-
-        var preflightView = new PreflightView( {
-            deferred: preflightCompletedDeferred,
-            model: this.connection
-        }).render();
         
+        try { // catch exceptions hidden by Q
+            var preflightView = new PreflightView( {
+                deferred: preflightCompletedDeferred,
+                model: this.connection,
+                mission: this.get('mission'),
+                parameters: appConfig.platforms[this.get('mission').get('platformId')].parameters
+            }).render();
+        } catch(e) {
+            console.log(e);
+            throw(e);
+        }
+
         // Initalize connection.
         now.ready(_.bind(function() {
 

--- a/app/routines/freeFlight/Routine.js
+++ b/app/routines/freeFlight/Routine.js
@@ -53,8 +53,10 @@ define([
 
             BaseRoutine.prototype.preflight.apply(this, [preflightCompletedDeferred]); // call parent code
 
-            // Upload specific parameters
-            this.on('change:connected', _.bind(function(model) {
+            // Upload specific parameters if defined in parameters file
+            if( false !== appConfig.platforms[this.get('mission').get('platformId')].parameters ) {
+
+               this.on('change:connected', _.bind(function(model) {
 
                 var parametersLoaded = _.bind(function() {
                         this.set( { 'paramsLoaded':true });
@@ -63,18 +65,18 @@ define([
                         $('#loadParameters .connected').show();
                 }, this);
 
-                    Q($.get('/drone/params/load')).then(_.bind(function(data) {
-                        parametersLoaded();
-                    }, function(xhr) {
-                        // on failure
-                        console.log(xhr);
-                    }, this));
-                    
-                    $('#loadParameters .disconnected').hide();
-                    $('#loadParameters .connecting').show();
+                Q($.get('/drone/params/load')).then(_.bind(function(data) {
+                    parametersLoaded();
+                }, function(xhr) {
+                    // on failure
+                    console.log(xhr);
+                }, this));
+
+                $('#loadParameters .disconnected').hide();
+                $('#loadParameters .connecting').show();
                 
             }, this));
-
+        }
 
         // Upload mission plan
         this.on('change:paramsLoaded', _.bind(function() {

--- a/app/routines/freeFlight/Templates/preflight.jade
+++ b/app/routines/freeFlight/Templates/preflight.jade
@@ -9,11 +9,14 @@
           ul.list-group.checklist
             li.list-group-item
               #preflightSitlConnectionManager.statusWidget
-            li.list-group-item
-              #loadParameters.statusWidget
-                .disconnected <span class="glyphicon glyphicon-tasks"></span> Flight parameters not loaded.
-                .connecting(style="display:none") <span class="glyphicon glyphicon-tasks"></span> Loading flight parameters&hellip;
-                .connected(style="display:none") <span class="glyphicon glyphicon-ok"></span> Flight parameters loaded.
+
+            if parameters
+              li.list-group-item
+                #loadParameters.statusWidget
+                  .disconnected <span class="glyphicon glyphicon-tasks"></span> Flight parameters not loaded.
+                  .connecting(style="display:none") <span class="glyphicon glyphicon-tasks"></span> Loading flight parameters&hellip;
+                  .connected(style="display:none") <span class="glyphicon glyphicon-ok"></span> Flight parameters loaded.
+
             li.list-group-item
               #loadMission.statusWidget
                 .disconnected <span class="glyphicon glyphicon-globe"></span> Mission not loaded.

--- a/app/routines/freeFlight/views/Preflight.js
+++ b/app/routines/freeFlight/views/Preflight.js
@@ -12,7 +12,8 @@ define(['backbone', 'JST',
         template: templates['app/routines/freeFlight/Templates/preflight'],
 
         initialize : function (options) {
-          this.options = options || {};
+            _.bindAll(this, 'render');
+            this.options = options || {};
         },
 
         events: {
@@ -25,8 +26,9 @@ define(['backbone', 'JST',
         },
 
         render: function() {
-
-            this.$el.html(this.template);
+            this.$el.html(this.template({
+                parameters: this.options.parameters
+            }));
 
             this.connectionView = new ConnectionWidget({
                 model: this.model,

--- a/assets/js/libs/platforms.js
+++ b/assets/js/libs/platforms.js
@@ -53,21 +53,17 @@ var sitlCopterParams = [
 // Some below are commented out to demonstrate structure, but they shouldn't
 // be in the GUI at this point.
 var platforms = [
-  // {
-  //   name: 'ArduPlane (Generic)',
-  //   type: 'plane',
-  //   payloads: [],
-  //   missions: ['SITL'],
-  //   id: 0
-  // },
-  // {
-  //   name: 'ArduCopter (Generic)',
-  //   type: 'copter',
-  //   payloads: [],
-  //   missions: ['SITL', 'Free Flight'],
-  //   id: 1,
-  //   parameters: sitlCopterParams
-  // },
+  {
+    name: 'ArduCopter (SITL)',
+    type: 'quadcopter',
+    payloads: [],
+    missions: ['Free Flight'],
+    id: 0,
+    parameters: sitlCopterParams,
+    defaults: {
+      topSpeed: 15 // kph
+    }
+  },
   {
     name: '3DR Iris',
     type: 'quadcopter',
@@ -79,8 +75,8 @@ var platforms = [
       'High-resolution mapping',
       'Digital elevation model'
     ],
-    id: 2,
-    parameters: sitlCopterParams,
+    id: 1,
+    parameters: false,
     defaults: {
       topSpeed: 10 // kph
     }

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -9,8 +9,8 @@ html(lang='en')
 		link(rel='icon', type='image/png', href='/images/afdc.png')
 		script(type="text/javascript", data-main="/javascripts/required", charset="utf-8", src="/javascripts/require.js")
 		script.
-			var app = app || {};
-			app.platforms = !{JSON.stringify(platforms)}
+			var appConfig = appConfig || {};
+			appConfig.platforms = !{JSON.stringify(platforms)}
 	body
 		nav#main-navbar.navbar.navbar-default(role="navigation")
 			.container-fluid


### PR DESCRIPTION
Also adds guard code that prevents the GCS from sending updated params to the platform if none are defined in the assets/js/libs/platforms.js file.  Reason being we always need to provision the SITL with params, but not always on other real platforms where we may want to manage the param set differently.
