### PR TITLE
removed reference to mavlink contained in etc/ and instead use npm to fetch it

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jade": "1.5.0",
     "jspack": "0.0.4",
     "less-middleware": "1.0.4",
-    "mavlink_ardupilotmega_v1.0": "file:./etc/mavlink_ardupilotmega_v1.0.tgz",
+    "mavlink_ardupilotmega_v1.0": "0.0.2",
     "moment": "2.7.0",
     "nconf": "0.6.9",
     "node-stringify": "0.0.18",


### PR DESCRIPTION
I'm guessing the reason for the local mavlink_ardupilotmega_v1.0.tgz in etc/ was that it didn't exist on NPM when this project started? Regardless, the local package caused issues for me on Linux. Using the version from NPM fixed the problem.
